### PR TITLE
Add support for invoice search.

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -193,6 +193,30 @@ class Sellapp {
 		});
 	}
 	/**
+	 * @param {string} field to query in descending order.
+	 * @return Returns a list of all the orders that have been placed in descending order by the passed field.
+	 */
+	 getAllOrdersDesc(field) {
+		const params = `invoices/search`;
+		const body = {
+			sort: [
+				{
+					field: field,
+					direction: "desc", /* Descending Direction */
+				}
+			]
+		};
+		return new Promise((resolve, reject) => {
+			this.makeRequest(params, body, "POST")
+				.then((data) => {
+					resolve(data);
+				})
+				.catch((err) => {
+					reject(err);
+				});
+		});
+	}
+	/**
 	 * @param {string} id Retrieves a listing/product by the entered ID.
 	 */
 	getProduct(id) {
@@ -555,7 +579,8 @@ class Sellapp {
 				url: this.url + params,
 				data: body,
 				headers: {
-					"Authorization": `Bearer ${this.api_key}`
+					"Authorization": `Bearer ${this.api_key}`,
+					"Content-Type": "application/json"
 				},
 				responseType: "json",
 				proxy: false


### PR DESCRIPTION
Adds api `getAllOrdersDesc` which returns a list of all invoices sorted by the input field.
Example: `API.getAllOrdersDesc( "created_at" )`

Adds `Content-Type` header to `makeRequest`